### PR TITLE
Bugfix and cleanup: Tesco, Waitrose and Iceland now show up again on postcode search

### DIFF
--- a/src/utils/geolocater.js
+++ b/src/utils/geolocater.js
@@ -1,3 +1,11 @@
+// Chain IDs for Foursquare:
+// Waitrose - 2fcb8360-9c63-0132-6632-3c15c2dde6c8
+// Tesco - 2fc927c0-9c63-0132-6632-3c15c2dde6c8
+// Sainsburys - 2fca29d0-9c63-0132-6632-3c15c2dde6c8
+// Morrisons - 2fcc8920-9c63-0132-6632-3c15c2dde6c8
+// Iceland - 2fcbdc20-9c63-0132-6632-3c15c2dde6c8
+// Asda - 2fcb9270-9c63-0132-6632-3c15c2dde6c8
+
 const axios = require('axios');
 
 const apiKey = process.env.MAPBOX_API_KEY;
@@ -21,7 +29,11 @@ const getLongLatFromPostcode = async (postcode) => {
 };
 
 const getSupermarketList = async ({ long, lat }, radius) => {
-  const urlSupermarkets = `https://api.foursquare.com/v3/places/search?ll=${lat},${long}&radius=${radius}&categories=17069&limit=50`;
+  // Comma seperated string of all Foursquare chain IDs for all UK supermarkets in app.  For each specific supermarket, see comment at the top of this file
+  const chains =
+    '2fcb8360-9c63-0132-6632-3c15c2dde6c8%2C2fc927c0-9c63-0132-6632-3c15c2dde6c8%2C2fca29d0-9c63-0132-6632-3c15c2dde6c8%2C2fcc8920-9c63-0132-6632-3c15c2dde6c8%2C2fcbdc20-9c63-0132-6632-3c15c2dde6c8%2C2fcb9270-9c63-0132-6632-3c15c2dde6c8';
+
+  const urlSupermarkets = `https://api.foursquare.com/v3/places/search?ll=${lat},${long}&radius=${radius}&chains=${chains}&limit=50`;
 
   try {
     const { data } = await axios.get(urlSupermarkets, {
@@ -40,11 +52,14 @@ const getSupermarketList = async ({ long, lat }, radius) => {
     // Create new array with supermarket names to check against DB that are currently supported.
     const supportedSupermarkets = [];
 
-    if (supermarkets.includes('Waitrose & Partners')) {
+    if (supermarkets.includes('Waitrose')) {
       supportedSupermarkets.push('waitrose');
     }
 
-    if (supermarkets.includes('Tesco Extra')) {
+    if (
+      supermarkets.includes('Tesco Extra') ||
+      supermarkets.includes('Tesco Express')
+    ) {
       supportedSupermarkets.push('tesco');
     }
 
@@ -67,43 +82,13 @@ const getSupermarketList = async ({ long, lat }, radius) => {
       supportedSupermarkets.push('asda');
     }
 
+    if (supermarkets.includes('Iceland')) {
+      supportedSupermarkets.push('iceland');
+    }
+
     return supportedSupermarkets;
   } catch (error) {
     console.log(error);
-  }
-};
-
-const getSupermarketListMapBox = async (longlat) => {
-  const urlSupermarkets = `https://api.mapbox.com/geocoding/v5/mapbox.places/supermarket.json?proximity=${longlat}&access_token=${apiKey}&limit=5`;
-
-  try {
-    const { data } = await axios.get(urlSupermarkets);
-
-    // Create array of all supermarkets near postcode.
-    const supermarkets = [];
-
-    data.features.forEach((supermarket) => {
-      supermarkets.push(supermarket.text);
-    });
-
-    // Create new array with supermarket names to check against DB that are currently supported.
-    const supportedSupermarkets = [];
-
-    if (supermarkets.includes('Waitrose & Partners')) {
-      supportedSupermarkets.push('waitrose');
-    }
-
-    if (supermarkets.includes('Tesco Extra')) {
-      supportedSupermarkets.push('tesco');
-    }
-
-    if (supermarkets.includes("Sainsbury's")) {
-      supportedSupermarkets.push("sainsbury's");
-    }
-
-    return supportedSupermarkets;
-  } catch (error) {
-    throw new Error(`*** An error occured in getSupermarketList: ${error} ***`);
   }
 };
 


### PR DESCRIPTION
Also included a reference on the chain ID for each supermarket that Foursquare uses in its GET request, in case they need to be altered/added to in the future.